### PR TITLE
Improve robustness

### DIFF
--- a/src/fit_em.jl
+++ b/src/fit_em.jl
@@ -138,7 +138,6 @@ function E_step!(
             end
         end
     end
-    robust && replace!(LL, -Inf => nextfloat(-Inf), Inf => log(prevfloat(Inf)))
     # get posterior of each category
     logsumexp!(c, LL) # c[:] = logsumexp(LL, dims=2)
     γ[:, :] .= exp.(LL .- c)

--- a/src/fit_em.jl
+++ b/src/fit_em.jl
@@ -124,13 +124,17 @@ function E_step!(
 ) where {T<:AbstractFloat}
     # evaluate likelihood for each type k
     for k in eachindex(dists)
-        logα = log(α[k])
-        robust && !isfinite(logα) && continue
-        distk = dists[k]
-        for n in eachindex(y)
-            logp = logpdf(distk, y[n])
-            if !robust || isfinite(logp)
+        logα, distk = log(α[k]), dists[k]
+        if robust
+            isfinite(logα) || continue
+            for n in eachindex(y)
+                logp = logpdf(distk, y[n])
+                isfinite(logp) || continue
                 LL[n, k] = logα + logp
+            end
+        else
+            for n in eachindex(y)
+                LL[n, k] = logα + logpdf(distk, y[n])
             end
         end
     end
@@ -151,13 +155,17 @@ function E_step!(
 )
     # evaluate likelihood for each type k
     for k in eachindex(dists)
-        logα = log(α[k])
-        robust && !isfinite(logα) && continue
-        distk = dists[k]
-        for n in axes(y, 2)
-            logp = logpdf(distk, y[:, n])
-            if !robust || isfinite(logp)
+        logα, distk = log(α[k]), dists[k]
+        if robust
+            isfinite(logα) || continue
+            for n in axes(y, 2)
+                logp = logpdf(distk, y[:, n])
+                isfinite(logp) || continue
                 LL[n, k] = logα + logp
+            end
+        else
+            for n in axes(y, 2)
+                LL[n, k] = logα + logpdf(distk, y[:, n])
             end
         end
     end

--- a/src/stochastic_em.jl
+++ b/src/stochastic_em.jl
@@ -59,8 +59,13 @@ function fit_mle!(
         # M-step
         # using ẑ, maximize (update) the parameters
         α[:] = length.(cat)/N
-        dists[:] = [fit_mle(dists[k], y[cat[k]]) for k = 1:K]
-
+        dists[:] = map(1:K) do k 
+                    if α[k] > 0
+                        fit_mle(dists[k], y[cat[k]])
+                    else
+                        dists[k]
+                    end
+                 end
         # E-step
         # evaluate likelihood for each type k
         E_step!(LL, c, γ, dists, α, y; robust = robust)
@@ -133,7 +138,13 @@ function fit_mle!(
         # M-step
         # using ẑ, maximize (update) the parameters
         α[:] = length.(cat)/N
-        dists[:] = [fit_mle(dists[k], y[:, cat[k]]) for k = 1:K]
+        dists[:] = map(1:K) do k 
+            if α[k] > 0
+                fit_mle(dists[k], y[:, cat[k]])
+            else
+                dists[k]
+            end
+         end
 
         # E-step
         # evaluate likelihood for each type k

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,10 +278,19 @@ end
     fit_mle(mix_bad_guess, X, maxiter = 1)
     
     try # make sure our test case is problematic after two iterations without robust option
-        fit_mle(mix_bad_guess, X, maxiter = 2) #triggers error
+        fit_mle(mix_bad_guess, X, maxiter = 20) #triggers error
+        @test false
     catch e
         @test true
     end
-    # no error thrown (however the EM did converged to some bad local maxima)
-    mix_mle_bad = fit_mle(mix_bad_guess, X, maxiter = 2000, robust = true)
+    begin 
+        #! no error thrown, however the EM converges to some bad local maxima!
+        mix_mle_bad = fit_mle(mix_bad_guess, X, maxiter = 2000, robust = true)
+        @test true
+    end
+    begin 
+        #! no error thrown, however the SEM has one mixture component with zero proba (remaining the same at every iteration)
+        mix_mle_S = fit_mle(mix_bad_guess, X, method = StochasticEM(), maxiter = 2000)
+        @test true
+    end
 end


### PR DESCRIPTION
This eliminates the common failures observed in
https://github.com/dmetivie/ExpectationMaximization.jl/issues/11#issuecomment-1817926977

The strategy is to stop updating a component when non-finite values are encountered. Obviously, this only helps if `robust=true`, but I'm a little unsure of when one wouldn't want that.